### PR TITLE
Artifactory redirect workaround

### DIFF
--- a/src/main/resources/detect-ps.ps1
+++ b/src/main/resources/detect-ps.ps1
@@ -224,7 +224,7 @@ function Invoke-WebRequestWrapper($Url, $ProxyInfo, $DownloadLocation = $null) {
         Write-Host ("  Reason: {0}" -f $_.Exception.StackTrace);
     }
 
-    return Invoke-WebRequest $Url -UseBasicParsing @parameters
+    return Invoke-WebRequest $Url -UseBasicParsing @parameters -UserAgent "PowerShell" # Workaround for https://www.jfrog.com/jira/si/jira.issueviews:issue-html/RTFACT-26216/RTFACT-26216.html
 }
 
 function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $DetectVersion, $ProxyInfo) {


### PR DESCRIPTION
Artifactory is redirecting based on user-agent which breaks downloading detect. This fix provides a user-agent namely "PowerShell" that Artifactory will not redirect. An empty user agent has issues on PowerShell 6.2.0 so we provide the user-agent "PowerShell".