### PR TITLE
Add basic retry mechanism to sig-repo jar download

### DIFF
--- a/src/main/resources/detect-sh.sh
+++ b/src/main/resources/detect-sh.sh
@@ -156,7 +156,7 @@ get_detect() {
   if [ ${USE_REMOTE} -eq 1 ]; then
     echo "getting ${DETECT_SOURCE} from remote"
     TEMP_DETECT_DESTINATION="${DETECT_DESTINATION}-temp"
-    curlReturn=$(curl ${DETECT_CURL_OPTS} --silent -w "%{http_code}" -L -o "${TEMP_DETECT_DESTINATION}" --create-dirs "${DETECT_SOURCE}")
+    curlReturn=$(curl ${DETECT_CURL_OPTS} --retry --silent -w "%{http_code}" -L -o "${TEMP_DETECT_DESTINATION}" --create-dirs "${DETECT_SOURCE}")
     if [[ 200 -eq ${curlReturn} ]]; then
       mv "${TEMP_DETECT_DESTINATION}" "${DETECT_DESTINATION}"
       if [[ -f ${LOCAL_FILE} ]]; then


### PR DESCRIPTION
During a recent attempt to plan maintenance for the binary repository backing sig-repo, it was determined that retry-less client behavior is complicating the ability to patch and maintain the system.

This pull request proposes the addition of basic retry logic - there are many options which can alter the behavior of the default retry. Note that `--fail` must be added if retry on 404 is desired (which will depend on sig-repo's behavior when down).

It might also be appropriate to setup the ability to disable or override the retry behavior via environment variable, similar to the base `DETECT_CURL_OPTS` setup.

Aside from determinations on what the default behavior should be, another addition that would be appropriate would be similar support in the powershell script (which based on surface research seems slightly more involved, and being unfamiliar with PS I decided would be better to exclude and allow someone better-versed to provide)