### PR TITLE
Fix bugs in detect shell template

### DIFF
--- a/src/main/resources/earlierversions/detect7.sh
+++ b/src/main/resources/earlierversions/detect7.sh
@@ -73,7 +73,7 @@ DETECT_CURL_OPTS=${DETECT_CURL_OPTS:-}
 # get and update the jar file when a new version releases.
 DETECT_DOWNLOAD_ONLY=${DETECT_DOWNLOAD_ONLY:-0}
 
-SCRIPT_ARGS=$("$@")
+SCRIPT_ARGS=$*
 LOGGABLE_SCRIPT_ARGS=""
 
 # This provides a way to get the script version (via, say, grep/sed). Do not change.

--- a/src/main/resources/earlierversions/detect7.sh
+++ b/src/main/resources/earlierversions/detect7.sh
@@ -4,7 +4,7 @@ echo "Detect Shell Script ${SCRIPT_VERSION}"
 
 get_path_separator() {
   # Performs a check to see if the system is Windows based.
-  if [[ `uname` == *"NT"* ]] || [[ `uname` == *"UWIN"* ]]; then
+  if [[ $(uname) == *"NT"* ]] || [[ $(uname) == *"UWIN"* ]]; then
     echo "\\"
   else
     echo "/"
@@ -73,7 +73,7 @@ DETECT_CURL_OPTS=${DETECT_CURL_OPTS:-}
 # get and update the jar file when a new version releases.
 DETECT_DOWNLOAD_ONLY=${DETECT_DOWNLOAD_ONLY:-0}
 
-SCRIPT_ARGS="$@"
+SCRIPT_ARGS=$("$@")
 LOGGABLE_SCRIPT_ARGS=""
 
 # This provides a way to get the script version (via, say, grep/sed). Do not change.
@@ -83,7 +83,7 @@ echo "Detect Shell Script ${SCRIPT_VERSION}"
 
 DETECT_BINARY_REPO_URL=https://sig-repo.synopsys.com
 
-for i in $*; do
+for i in "$@"; do
   if [[ $i == --blackduck.hub.password=* ]]; then
     LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS --blackduck.hub.password=<redacted>"
   elif [[ $i == --blackduck.hub.proxy.password=* ]]; then
@@ -118,7 +118,7 @@ get_detect() {
     if [[ -z "${DETECT_RELEASE_VERSION}" ]]; then
       VERSION_CURL_CMD="curl ${DETECT_CURL_OPTS} --silent --header \"X-Result-Detail: info\" '${DETECT_BINARY_REPO_URL}/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=${DETECT_VERSION_KEY}'"
       VERSION_EXTRACT_CMD="${VERSION_CURL_CMD} | grep \"${DETECT_VERSION_KEY}\" | sed 's/[^[]*[^\"]*\"\([^\"]*\).*/\1/'"
-      DETECT_SOURCE=$(eval ${VERSION_EXTRACT_CMD})
+      DETECT_SOURCE=$(eval "${VERSION_EXTRACT_CMD}")
       if [[ -z "${DETECT_SOURCE}" ]]; then
         echo "Unable to derive the location of ${DETECT_VERSION_KEY} from response to: ${VERSION_CURL_CMD}"
         USE_LOCAL=1
@@ -136,12 +136,12 @@ get_detect() {
 
   if [[ USE_LOCAL -eq 1 ]] && [[ -f "${LOCAL_FILE}" ]]; then
     echo "Found local file ${LOCAL_FILE}"
-    DETECT_FILENAME=`cat ${LOCAL_FILE}`
+    DETECT_FILENAME=$(cat "${LOCAL_FILE}")
   elif [[ USE_LOCAL -eq 1 ]]; then
     echo "${LOCAL_FILE} is missing and unable to communicate with a Detect source."
-    exit -1
+    exit 1
   else
-    DETECT_FILENAME=${DETECT_FILENAME:-$(awk -F "/" '{print $NF}' <<< $DETECT_SOURCE)}
+    DETECT_FILENAME=${DETECT_FILENAME:-$(awk -F "/" '{print $NF}' <<< "$DETECT_SOURCE")}
   fi
   DETECT_DESTINATION="${DETECT_JAR_DOWNLOAD_DIR}${PATH_SEPARATOR}${DETECT_FILENAME}"
 
@@ -156,7 +156,7 @@ get_detect() {
   if [ ${USE_REMOTE} -eq 1 ]; then
     echo "getting ${DETECT_SOURCE} from remote"
     TEMP_DETECT_DESTINATION="${DETECT_DESTINATION}-temp"
-    curlReturn=$(curl ${DETECT_CURL_OPTS} --silent -w "%{http_code}" -L -o "${TEMP_DETECT_DESTINATION}" --create-dirs "${DETECT_SOURCE}")
+    curlReturn=$(curl "${DETECT_CURL_OPTS}" --silent -w "%{http_code}" -L -o "${TEMP_DETECT_DESTINATION}" --create-dirs "${DETECT_SOURCE}")
     if [[ 200 -eq ${curlReturn} ]]; then
       mv "${TEMP_DETECT_DESTINATION}" "${DETECT_DESTINATION}"
       if [[ -f ${LOCAL_FILE} ]]; then
@@ -166,7 +166,7 @@ get_detect() {
       echo "saved ${DETECT_SOURCE} to ${DETECT_DESTINATION}"
     else
       echo "The curl response was ${curlReturn}, which is not successful - please check your configuration and environment."
-      exit -1
+      exit 1
     fi
   fi
 }

--- a/src/main/resources/templates/detect-sh.sh
+++ b/src/main/resources/templates/detect-sh.sh
@@ -4,7 +4,7 @@ echo "Detect Shell Script ${SCRIPT_VERSION}"
 
 get_path_separator() {
   # Performs a check to see if the system is Windows based.
-  if [[ `uname` == *"NT"* ]] || [[ `uname` == *"UWIN"* ]]; then
+  if [[ $(uname) == *"NT"* ]] || [[ $(uname) == *"UWIN"* ]]; then
     echo "\\"
   else
     echo "/"
@@ -88,7 +88,7 @@ echo "Detect Shell Script ${SCRIPT_VERSION}"
 
 DETECT_BINARY_REPO_URL=https://sig-repo.synopsys.com
 
-for i in $*; do
+for i in "$@"; do
   if [[ $i == --blackduck.hub.password=* ]]; then
     LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS --blackduck.hub.password=<redacted>"
   elif [[ $i == --blackduck.hub.proxy.password=* ]]; then
@@ -123,7 +123,7 @@ get_detect() {
     if [[ -z "${DETECT_RELEASE_VERSION}" ]]; then
       VERSION_CURL_CMD="curl ${DETECT_CURL_OPTS} --silent --header \"X-Result-Detail: info\" '${DETECT_BINARY_REPO_URL}/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=${DETECT_VERSION_KEY}'"
       VERSION_EXTRACT_CMD="${VERSION_CURL_CMD} | grep \"${DETECT_VERSION_KEY}\" | sed 's/[^[]*[^\"]*\"\([^\"]*\).*/\1/'"
-      DETECT_SOURCE=$(eval ${VERSION_EXTRACT_CMD})
+      DETECT_SOURCE=$(eval "${VERSION_EXTRACT_CMD}")
       if [[ -z "${DETECT_SOURCE}" ]]; then
         echo "Unable to derive the location of ${DETECT_VERSION_KEY} from response to: ${VERSION_CURL_CMD}"
         USE_LOCAL=1
@@ -141,12 +141,12 @@ get_detect() {
 
   if [[ USE_LOCAL -eq 1 ]] && [[ -f "${LOCAL_FILE}" ]]; then
     echo "Found local file ${LOCAL_FILE}"
-    DETECT_FILENAME=`cat ${LOCAL_FILE}`
+    DETECT_FILENAME=$(cat "${LOCAL_FILE}")
   elif [[ USE_LOCAL -eq 1 ]]; then
     echo "${LOCAL_FILE} is missing and unable to communicate with a Detect source."
-    exit -1
+    exit 1
   else
-    DETECT_FILENAME=${DETECT_FILENAME:-$(awk -F "/" '{print $NF}' <<< $DETECT_SOURCE)}
+    DETECT_FILENAME=${DETECT_FILENAME:-$(awk -F "/" '{print $NF}' <<< "$DETECT_SOURCE")}
   fi
   DETECT_DESTINATION="${DETECT_JAR_DOWNLOAD_DIR}${PATH_SEPARATOR}${DETECT_FILENAME}"
 
@@ -161,7 +161,7 @@ get_detect() {
   if [ ${USE_REMOTE} -eq 1 ]; then
     echo "getting ${DETECT_SOURCE} from remote"
     TEMP_DETECT_DESTINATION="${DETECT_DESTINATION}-temp"
-    curlReturn=$(curl ${DETECT_CURL_OPTS} --silent -w "%{http_code}" -L -o "${TEMP_DETECT_DESTINATION}" --create-dirs "${DETECT_SOURCE}")
+    curlReturn=$(curl "${DETECT_CURL_OPTS}" --silent -w "%{http_code}" -L -o "${TEMP_DETECT_DESTINATION}" --create-dirs "${DETECT_SOURCE}")
     if [[ 200 -eq ${curlReturn} ]]; then
       mv "${TEMP_DETECT_DESTINATION}" "${DETECT_DESTINATION}"
       if [[ -f ${LOCAL_FILE} ]]; then
@@ -171,7 +171,7 @@ get_detect() {
       echo "saved ${DETECT_SOURCE} to ${DETECT_DESTINATION}"
     else
       echo "The curl response was ${curlReturn}, which is not successful - please check your configuration and environment."
-      exit -1
+      exit 1
     fi
   fi
 }


### PR DESCRIPTION
- fixes array bug when passing options to command-line script (Noted in a currently open [PR](https://github.com/synopsys-sig/synopsys-detect-scripts/pull/10))
- remove using backticks as this was [deprecated](https://www.redhat.com/sysadmin/backtick-operator-vs-parens)
- add double quoting around variables that could have accidental/unintended splitting when invoked
- add proper exit code for failures (negative numbers are not interpreted by SIGNALS)
- update detect7.sh in earlier versions