### PR TITLE
Remove Detect 6 info from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,4 +2,3 @@
 <h3>Landing page for Detect script downloads.</h3>
   
   Please use this URL + /detectN.sh or /detectN.ps1 where N is the Detect major version number.
-  Use /detect.sh or /detect.ps1 for Detect version 6.


### PR DESCRIPTION
Remove Detect 6 reference from landing page https://detect.synopsys.com/