### PR TITLE
Update Powershell scripts to support forward and backward version compatibility

### DIFF
--- a/src/main/resources/earlierversions/detect8.ps1
+++ b/src/main/resources/earlierversions/detect8.ps1
@@ -232,11 +232,28 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
-            $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
+            $detectVersionKeySplit = $DetectVersionKey.split("_")
+            $detectVersionChar = $detectVersionKeySplit[-1]
+            $detectVersionNumber = [int]$detectVersionChar
+
+            if($detectVersionNumber -le 9) {
+                $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
+            } else {
+                $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
+            }
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
         else {
-            $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
+            $detectVersionSplit= $DetectVersion.split(".")
+            $detectVersionChar = $detectVersionSplit[0]
+            $detectVersionNumber = [int]$detectVersionChar
+
+
+            if($detectVersionNumber -le 9) {
+                $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
+            } else {
+                $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
+            }
         }
     }
 

--- a/src/main/resources/earlierversions/detect8.ps1
+++ b/src/main/resources/earlierversions/detect8.ps1
@@ -236,7 +236,7 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionChar = $detectVersionKeySplit[-1]
             $detectVersionNumber = [int]$detectVersionChar
 
-            # If major version is 9 or less, than download from synopsys location or else blackduck
+            # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
                 $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
@@ -249,7 +249,7 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionChar = $detectVersionSplit[0] # Get the major version from the variable
             $detectVersionNumber = [int]$detectVersionChar
 
-            # If major version is 9 or less, than download from synopsys location or else blackduck
+            # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
                 $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {

--- a/src/main/resources/earlierversions/detect8.ps1
+++ b/src/main/resources/earlierversions/detect8.ps1
@@ -232,10 +232,11 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
-            $detectVersionKeySplit = $DetectVersionKey.split("_")
+            $detectVersionKeySplit = $DetectVersionKey.split("_") # Split the key provided, as an example key would be of form: DETECT_LATEST_9
             $detectVersionChar = $detectVersionKeySplit[-1]
             $detectVersionNumber = [int]$detectVersionChar
 
+            # If major version is 9 or less, than download from synopsys location or else blackduck
             if($detectVersionNumber -le 9) {
                 $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
@@ -244,11 +245,11 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
         else {
-            $detectVersionSplit= $DetectVersion.split(".")
-            $detectVersionChar = $detectVersionSplit[0]
+            $detectVersionSplit= $DetectVersion.split(".") # Split the key provided, as an example version would be of form: 8.11.2
+            $detectVersionChar = $detectVersionSplit[0] # Get the major version from the variable
             $detectVersionNumber = [int]$detectVersionChar
 
-
+            # If major version is 9 or less, than download from synopsys location or else blackduck
             if($detectVersionNumber -le 9) {
                 $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {

--- a/src/main/resources/earlierversions/detect9.ps1
+++ b/src/main/resources/earlierversions/detect9.ps1
@@ -232,11 +232,27 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
-            $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
+            $detectVersionKeySplit = $DetectVersionKey.split("_")
+            $detectVersionChar = $detectVersionKeySplit[-1]
+            $detectVersionNumber = [int]$detectVersionChar
+
+            if($detectVersionNumber -le 9) {
+                $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
+            } else {
+                $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
+            }
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
         else {
-            $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
+            $detectVersionSplit= $DetectVersion.split(".")
+            $detectVersionChar = $detectVersionSplit[0]
+            $detectVersionNumber = [int]$detectVersionChar
+
+            if($detectVersionNumber -le 9) {
+                $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
+            } else {
+                $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
+            }
         }
     }
 

--- a/src/main/resources/earlierversions/detect9.ps1
+++ b/src/main/resources/earlierversions/detect9.ps1
@@ -236,7 +236,7 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionChar = $detectVersionKeySplit[-1]
             $detectVersionNumber = [int]$detectVersionChar
 
-            # If major version is 9 or less, than download from synopsys location or else blackduck
+            # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
                 $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
@@ -249,7 +249,7 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionChar = $detectVersionSplit[0] # Get the major version from the variable
             $detectVersionNumber = [int]$detectVersionChar
 
-            # If major version is 9 or less, than download from synopsys location or else blackduck
+            # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
                 $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {

--- a/src/main/resources/earlierversions/detect9.ps1
+++ b/src/main/resources/earlierversions/detect9.ps1
@@ -232,10 +232,11 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
-            $detectVersionKeySplit = $DetectVersionKey.split("_")
+            $detectVersionKeySplit = $DetectVersionKey.split("_") # Split the key provided, as an example key would be of form: DETECT_LATEST_9
             $detectVersionChar = $detectVersionKeySplit[-1]
             $detectVersionNumber = [int]$detectVersionChar
 
+            # If major version is 9 or less, than download from synopsys location or else blackduck
             if($detectVersionNumber -le 9) {
                 $DetectVersionUrl = "https://sig-repo.synopsys.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
@@ -244,10 +245,11 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
         else {
-            $detectVersionSplit= $DetectVersion.split(".")
-            $detectVersionChar = $detectVersionSplit[0]
+            $detectVersionSplit= $DetectVersion.split(".") # Split the key provided, as an example version would be of form: 8.11.2
+            $detectVersionChar = $detectVersionSplit[0] # Get the major version from the variable
             $detectVersionNumber = [int]$detectVersionChar
 
+            # If major version is 9 or less, than download from synopsys location or else blackduck
             if($detectVersionNumber -le 9) {
                 $DetectSource = "https://sig-repo.synopsys.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -232,11 +232,25 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
-            $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
+            $lastCharOfKey = $DetectVersionKey[-1]
+            $versionNumber = [int]$lastCharOfKey
+            if($versionNumber -le 9) {
+                $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
+            } else {
+                $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
+            }
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
         else {
-            $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
+            $detectVersionChar = $DetectVersion[0]
+            $detectVersionNumber = [int]$detectVersionChar
+
+            if($detectVersionNumber -le 9) {
+                $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
+            } else {
+                $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
+            }
+
         }
     }
 

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -233,22 +233,20 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
             $lastCharOfKey = $DetectVersionKey[-1]
-            $versionNumber = [int]$lastCharOfKey
+#            $versionNumber = [int]$lastCharOfKey
 
-            Write-Host "Version Number '$versionNumber'"
-
-            if($versionNumber -le 9) {
-                $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
-            } else {
+            if($lastCharOfKey/1 -le 9) {
                 $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
+            } else {
+                $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
             }
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
         else {
             $detectVersionChar = $DetectVersion[0]
-            $detectVersionNumber = [int]$detectVersionChar
+#            $detectVersionNumber = [int]$detectVersionChar
 
-            if($detectVersionChar -le 9) {
+            if($detectVersionChar/1 -le 9) {
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -232,10 +232,11 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
-            $lastCharOfKey = $DetectVersionKey[-1]
-            $versionNumber = [int][string]$lastCharOfKey
+            $detectVersionKeySplit = $DetectVersionKey.split("_")
+            $detectVersionChar = $detectVersionKeySplit[-1]
+            $detectVersionNumber = [int]$detectVersionChar
 
-            if($versionNumber -le 9) {
+            if($detectVersionNumber -le 9) {
                 $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
                 $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
@@ -243,8 +244,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
         else {
-            $detectVersionChar = $DetectVersion[0]
-            $detectVersionNumber = [int][string]$detectVersionChar
+            $detectVersionSplit= $DetectVersion.split(".")
+            $detectVersionChar = $detectVersionSplit[0]
+            $detectVersionNumber = [int]$detectVersionChar
 
             if($detectVersionNumber -le 9) {
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -234,6 +234,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
         if ($DetectVersion -eq "") {
             $lastCharOfKey = $DetectVersionKey[-1]
             $versionNumber = [int]$lastCharOfKey
+
+            Write-Host "Version Number '$versionNumber'"
+
             if($versionNumber -le 9) {
                 $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
             } else {
@@ -245,21 +248,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionChar = $DetectVersion[0]
             $detectVersionNumber = [int]$detectVersionChar
 
-            Write-Host "Detect Version Number '$detectVersionNumber'"
-            Write-Host "Detect Version First Char '$detectVersionChar'"
-            if($detectVersionChar -match '^\d$')
-            {
-                Write-Host "Integer"
-            }
-            else
-            {
-                Write-Host "String"
-            }
-            if($detectVersionNumber -le 9) {
-                Write-Host "Detect 9 space '$detectVersionNumber' '$detectVersionChar'"
+            if($detectVersionChar -le 9) {
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {
-                Write-Host "Detect 10 space '$detectVersionNumber' '$detectVersionChar'"
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
             }
 

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -236,7 +236,7 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionChar = $detectVersionKeySplit[-1]
             $detectVersionNumber = [int]$detectVersionChar
 
-            # If major version is 9 or less, than download from synopsys location or else blackduck
+            # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
                 $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
@@ -249,7 +249,7 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionChar = $detectVersionSplit[0] # Get the major version from the variable
             $detectVersionNumber = [int]$detectVersionChar
 
-            # If major version is 9 or less, than download from synopsys location or else blackduck
+            # If major version is 9 or less, than download from com/synopsys/integration location or else com/blackduck/integration
             if($detectVersionNumber -le 9) {
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -245,9 +245,12 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionChar = $DetectVersion[0]
             $detectVersionNumber = [int]$detectVersionChar
 
+            Write-Host "Detect Version Number '$detectVersionNumber'"
             if($detectVersionNumber -le 9) {
+                Write-Host "Detect 10 space '$detectVersionNumber'"
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {
+                Write-Host "Detect 9 space '$detectVersionNumber'"
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
             }
 

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -233,9 +233,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
             $lastCharOfKey = $DetectVersionKey[-1]
-#            $versionNumber = [int]$lastCharOfKey
+            $versionNumber = [int][string]$lastCharOfKey
 
-            if($lastCharOfKey/1 -le 9) {
+            if($versionNumber -le 9) {
                 $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
                 $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/blackduck/integration/detect?properties=" + $DetectVersionKey
@@ -244,9 +244,9 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
         }
         else {
             $detectVersionChar = $DetectVersion[0]
-#            $detectVersionNumber = [int]$detectVersionChar
+            $detectVersionNumber = [int][string]$detectVersionChar
 
-            if($detectVersionChar/1 -le 9) {
+            if($detectVersionNumber -le 9) {
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -246,11 +246,20 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $detectVersionNumber = [int]$detectVersionChar
 
             Write-Host "Detect Version Number '$detectVersionNumber'"
+            Write-Host "Detect Version First Char '$detectVersionChar'"
+            if($detectVersionChar -match '^\d$')
+            {
+                Write-Host "Integer"
+            }
+            else
+            {
+                Write-Host "String"
+            }
             if($detectVersionNumber -le 9) {
-                Write-Host "Detect 10 space '$detectVersionNumber'"
+                Write-Host "Detect 9 space '$detectVersionNumber' '$detectVersionChar'"
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {
-                Write-Host "Detect 9 space '$detectVersionNumber'"
+                Write-Host "Detect 10 space '$detectVersionNumber' '$detectVersionChar'"
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/blackduck/integration/detect/" + $DetectVersion + "/detect-" + $DetectVersion + ".jar"
             }
 

--- a/src/main/resources/templates/detect-ps.ps1
+++ b/src/main/resources/templates/detect-ps.ps1
@@ -232,10 +232,11 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
 
     if ($DetectSource -eq "") {
         if ($DetectVersion -eq "") {
-            $detectVersionKeySplit = $DetectVersionKey.split("_")
+            $detectVersionKeySplit = $DetectVersionKey.split("_") # Split the key provided, as an example key would be of form: DETECT_LATEST_9
             $detectVersionChar = $detectVersionKeySplit[-1]
             $detectVersionNumber = [int]$detectVersionChar
 
+            # If major version is 9 or less, than download from synopsys location or else blackduck
             if($detectVersionNumber -le 9) {
                 $DetectVersionUrl = "https://repo.blackduck.com/api/storage/bds-integrations-release/com/synopsys/integration/synopsys-detect?properties=" + $DetectVersionKey
             } else {
@@ -244,10 +245,11 @@ function Get-DetectJar ($DetectFolder, $DetectSource, $DetectVersionKey, $Detect
             $DetectSource = Receive-DetectSource -ProxyInfo $ProxyInfo -DetectVersionUrl $DetectVersionUrl -DetectVersionKey $DetectVersionKey
         }
         else {
-            $detectVersionSplit= $DetectVersion.split(".")
-            $detectVersionChar = $detectVersionSplit[0]
+            $detectVersionSplit= $DetectVersion.split(".") # Split the key provided, as an example version would be of form: 8.11.2
+            $detectVersionChar = $detectVersionSplit[0] # Get the major version from the variable
             $detectVersionNumber = [int]$detectVersionChar
 
+            # If major version is 9 or less, than download from synopsys location or else blackduck
             if($detectVersionNumber -le 9) {
                 $DetectSource = "https://repo.blackduck.com/bds-integrations-release/com/synopsys/integration/synopsys-detect/" + $DetectVersion + "/synopsys-detect-" + $DetectVersion + ".jar"
             } else {


### PR DESCRIPTION
This PR adds the logic for backward and forward compatibility to find the right path to download Detect Jar. Currently, as discussed detect8 and detect9 scripts will use sig-repo until February to download jars but the template scripts will use repo.blackduck.com to download jars. The two env variables which will be supported by backward and forward compatibility are DETECT_LATEST_RELEASE_VERSION and DETECT_VERSION_KEY. The format for passing the value in these variables is mentioned in https://documentation.blackduck.com/bundle/detect/page/scripts/overview.html. 

Fixes IDETECT-4543