### PR TITLE
Add detect.llm.api.key to redacted properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 group = 'com.blackduck.integration'
-version = '3.4.0-SNAPSHOT'
+version = '3.5.0-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.simple'
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 group = 'com.blackduck.integration'
-version = '3.5.0-SNAPSHOT'
+version = '3.4.1-SNAPSHOT'
 
 apply plugin: 'com.blackduck.integration.simple'
 

--- a/src/main/resources/templates/detect-sh.sh
+++ b/src/main/resources/templates/detect-sh.sh
@@ -131,6 +131,8 @@ for i in $*; do
     LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS --blackduck.api.token=<redacted>"
   elif [[ $i == --polaris.access.token=* ]]; then
     LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS --polaris.access.token=<redacted>"
+  elif [[ $i == --detect.llm.api.key=* ]]; then
+    LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS --detect.llm.api.key=<redacted>"
   else
     LOGGABLE_SCRIPT_ARGS="$LOGGABLE_SCRIPT_ARGS $i"
   fi


### PR DESCRIPTION
This new property is available with Detect versions 11.2.0 and beyond. We will not be regenerating previous scripts. This will only affect detect11.sh and detect.sh -- powershell scripts will be addressed by IDETECT-4983