### PR TITLE
Update dependencies for EU CRA fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     constraints {
         implementation 'com.google.guava:guava:32.0.1-jre'
     }
-    implementation enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.18.6')
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.18.6')
     implementation 'com.blackduck.integration:blackduck-common:68.0.1'
     implementation 'org.freemarker:freemarker:2.3.31'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,15 +60,10 @@ task generateScripts(type: JavaExec) {
     args(jar.getArchiveFile().get().asFile, "scripts", "${project.buildDir}/libs/")
 }
 
-configurations.all {
-    if (it.canBeResolved) {
-        resolutionStrategy {
-            force 'com.google.guava:guava:32.0.1-jre'
-        }
-    }
-}
-
 dependencies {
+    constraints {
+        implementation 'com.google.guava:guava:32.0.1-jre'
+    }
     implementation enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.18.6')
     implementation 'com.blackduck.integration:blackduck-common:68.0.1'
     implementation 'org.freemarker:freemarker:2.3.31'

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,6 @@ task generateScripts(type: JavaExec) {
 }
 
 dependencies {
-    implementation 'com.blackduck.integration:blackduck-common:67.0.17'
+    implementation 'com.blackduck.integration:blackduck-common:68.0.1'
     implementation 'org.freemarker:freemarker:2.3.31'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath "com.blackduck.integration:common-gradle-plugin:${managedCgpVersion}"
-        classpath 'com.blackduck.integration:integration-rest:11.0.0'
+        classpath 'com.blackduck.integration:integration-rest:11.1.4'
         classpath 'org.codehaus.groovy:groovy-all:2.4.12'
         classpath 'org.junit.jupiter:junit-jupiter:5.4.2'
         classpath 'org.mockito:mockito-core:2.+'
@@ -60,7 +60,16 @@ task generateScripts(type: JavaExec) {
     args(jar.getArchiveFile().get().asFile, "scripts", "${project.buildDir}/libs/")
 }
 
+configurations.all {
+    if (it.canBeResolved) {
+        resolutionStrategy {
+            force 'com.google.guava:guava:32.0.1-jre'
+        }
+    }
+}
+
 dependencies {
+    implementation enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.18.6')
     implementation 'com.blackduck.integration:blackduck-common:68.0.1'
     implementation 'org.freemarker:freemarker:2.3.31'
 }


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5081

**Description**

 This pull request bumps the `blackduck-common` to the latest release `68.0.1`. And, it brings the `blackduck-common-api` version to the latest release `2023.4.2.15`,  the `phone-home-client` version to the latest release `7.0.3`,  `integration-bdio` version to the latest release `27.0.5`.

The version upgrades bring the latest release of `integration-common:27.0.4` transitively. And, it updates  the direct dependency  `json-path` from `2.9.0` to `2.10.0` to resolve a transitive vulnerable dependency as part of the EU CRA compliance effort.
 
`json-path:2.9.0` pulls in `json-smart:2.5.0`, which carries **CVE-2024-57699 (BDSA-2025-0966)**. 
This update transitively brings in `json-smart:2.6.0`, which is free of this vulnerability, and thus the safe version flows to all downstream consumers automatically.

This also updates and pins guava from `30.1.1` to `32.0.1-jre` to fix CVE-2020-8908 and CVE-2023-2976.
And, also updates `jackson-bom` from `2.15.0` to `2.18.6` to fix BDSA-2026-6606.