### PR TITLE
Update blackduck-common for EU CRA Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,6 @@ dependencies {
         implementation 'com.google.guava:guava:32.0.1-jre'
     }
     implementation platform('com.fasterxml.jackson:jackson-bom:2.18.6')
-    implementation 'com.blackduck.integration:blackduck-common:68.0.1'
+    implementation 'com.blackduck.integration:blackduck-common:68.0.2'
     implementation 'org.freemarker:freemarker:2.3.31'
 }


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5081

**Description**

This pull request bumps the `blackduck-common` to the latest release `68.0.2`. And, it brings the `bdio2` version to the latest release `4.0.1`.

The version upgrade transitively upgrades `jackson-core`, `jackson-databind`, `jackson-annotations` from `2.15.0` to `2.18.6` to resolve BDSA-2026-6606 exploitable vulnerability.
This also changes transitive dependency `guava` from `30.1.1-jre` to `32.0.1-jre` to resolve BDSA-2020-3736
(CVE-2020-8908) exploitable vulnerability.  

As part of the EU CRA compliance effort, these upgrades removes exploitable vulnerabilities in the `detect-scripts`.

---

**Note:** This pull request depends on the merge of this [pull request](https://github.com/blackducksoftware/blackduck-common/pull/478) in `blackduck-common` library 