### PR TITLE
Update jackson-bom for EU CRA Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     constraints {
         implementation 'com.google.guava:guava:32.0.1-jre'
     }
-    implementation platform('com.fasterxml.jackson:jackson-bom:2.18.6')
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.22.0')
     implementation 'com.blackduck.integration:blackduck-common:68.0.2'
     implementation 'org.freemarker:freemarker:2.3.31'
 }


### PR DESCRIPTION
**JIRA Ticket**

IDETECT-5081

**Description**

This pull request bumps the `jackson-bom` from `2.18.6` to `2.22.0` to fix **BDSA-2026-16110** (CVE-2026-54512) caused by `jackson-databind:2.18.6`